### PR TITLE
feat: isolate wallet sync into dedicated job channel

### DIFF
--- a/bria.yml
+++ b/bria.yml
@@ -5,10 +5,13 @@
 #   process_all_payout_queues_delay: 2
 #   respawn_all_outbox_handlers_delay: 5
 #   runners:
-#     account_main:
+#     payout:
 #       min_concurrency: 6
 #       max_concurrency: 10
-#     critical:
+#     wallet_sync:
+#       min_concurrency: 2
+#       max_concurrency: 4
+#     batch_finalization:
 #       min_concurrency: 6
 #       max_concurrency: 10
 #     maintenance:

--- a/src/job/config.rs
+++ b/src/job/config.rs
@@ -20,6 +20,7 @@ pub struct JobsConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct JobRunnersConfig {
     #[serde(default = "default_runner_concurrency")]
     pub payout: JobRunnerConcurrencyConfig,

--- a/src/job/config.rs
+++ b/src/job/config.rs
@@ -22,9 +22,11 @@ pub struct JobsConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JobRunnersConfig {
     #[serde(default = "default_runner_concurrency")]
-    pub account_main: JobRunnerConcurrencyConfig,
+    pub payout: JobRunnerConcurrencyConfig,
+    #[serde(default = "default_wallet_sync_runner")]
+    pub wallet_sync: JobRunnerConcurrencyConfig,
     #[serde(default = "default_runner_concurrency")]
-    pub critical: JobRunnerConcurrencyConfig,
+    pub batch_finalization: JobRunnerConcurrencyConfig,
     #[serde(default = "default_maintenance_runner")]
     pub maintenance: JobRunnerConcurrencyConfig,
 }
@@ -64,8 +66,9 @@ impl Default for JobsConfig {
 impl Default for JobRunnersConfig {
     fn default() -> Self {
         Self {
-            account_main: default_runner_concurrency(),
-            critical: default_runner_concurrency(),
+            payout: default_runner_concurrency(),
+            wallet_sync: default_wallet_sync_runner(),
+            batch_finalization: default_runner_concurrency(),
             maintenance: default_maintenance_runner(),
         }
     }
@@ -130,6 +133,13 @@ fn default_runner_concurrency() -> JobRunnerConcurrencyConfig {
 }
 
 fn default_maintenance_runner() -> JobRunnerConcurrencyConfig {
+    JobRunnerConcurrencyConfig {
+        min_concurrency: 2,
+        max_concurrency: 4,
+    }
+}
+
+fn default_wallet_sync_runner() -> JobRunnerConcurrencyConfig {
     JobRunnerConcurrencyConfig {
         min_concurrency: 2,
         max_concurrency: 4,

--- a/src/job/executor.rs
+++ b/src/job/executor.rs
@@ -52,6 +52,7 @@ impl<'a> JobExecutor<'a> {
 
     #[instrument(name = "execute_job", skip_all, fields(
             job_id, job_name, checkpoint_json, attempt, last_attempt,
+            queue_wait_ms, execution_duration_ms,
             error, error.level, error.message
     ), err)]
     pub async fn execute<T, E, R, F>(mut self, func: F) -> Result<T, E>
@@ -61,11 +62,17 @@ impl<'a> JobExecutor<'a> {
         R: std::future::Future<Output = Result<T, E>>,
         F: FnOnce(Option<T>) -> R,
     {
+        self.record_queue_wait().await;
         let mut data = JobData::<T>::from_raw_payload(self.job.raw_json()).unwrap();
         let keep_alive_handle = self.spawn_keep_alive(data.job_meta.wait_till_next_attempt);
 
         let completed = self.checkpoint_attempt(&mut data).await?;
+        let started_at = std::time::Instant::now();
         let result = func(data.data).await;
+        Span::current().record(
+            "execution_duration_ms",
+            tracing::field::display(started_at.elapsed().as_millis()),
+        );
 
         keep_alive_handle.stop().await;
 
@@ -75,6 +82,21 @@ impl<'a> JobExecutor<'a> {
             self.job.complete().await?;
         }
         result
+    }
+
+    async fn record_queue_wait(&self) {
+        let queue_wait_ms = sqlx::query_scalar::<_, i64>(
+            "SELECT GREATEST(0, ((EXTRACT(EPOCH FROM (now() - COALESCE(attempt_at, created_at))) * 1000)::BIGINT)) FROM mq_msgs WHERE id = $1",
+        )
+            .bind(self.job.id())
+            .fetch_optional(self.job.pool())
+            .await;
+
+        let Ok(Some(queue_wait_ms)) = queue_wait_ms else {
+            return;
+        };
+
+        Span::current().record("queue_wait_ms", tracing::field::display(queue_wait_ms));
     }
 
     fn spawn_keep_alive(&self, mut interval: Duration) -> KeepAliveHandle {

--- a/src/job/executor.rs
+++ b/src/job/executor.rs
@@ -70,7 +70,7 @@ impl<'a> JobExecutor<'a> {
         let result = func(data.data).await;
         Span::current().record(
             "execution_duration_ms",
-            tracing::field::display(started_at.elapsed().as_millis()),
+            started_at.elapsed().as_millis() as u64,
         );
 
         keep_alive_handle.stop().await;

--- a/src/job/executor.rs
+++ b/src/job/executor.rs
@@ -52,7 +52,7 @@ impl<'a> JobExecutor<'a> {
 
     #[instrument(name = "execute_job", skip_all, fields(
             job_id, job_name, checkpoint_json, attempt, last_attempt,
-            queue_wait_ms, execution_duration_ms,
+            execution_duration_ms,
             error, error.level, error.message
     ), err)]
     pub async fn execute<T, E, R, F>(mut self, func: F) -> Result<T, E>
@@ -62,7 +62,6 @@ impl<'a> JobExecutor<'a> {
         R: std::future::Future<Output = Result<T, E>>,
         F: FnOnce(Option<T>) -> R,
     {
-        self.record_queue_wait().await;
         let mut data = JobData::<T>::from_raw_payload(self.job.raw_json()).unwrap();
         let keep_alive_handle = self.spawn_keep_alive(data.job_meta.wait_till_next_attempt);
 
@@ -82,21 +81,6 @@ impl<'a> JobExecutor<'a> {
             self.job.complete().await?;
         }
         result
-    }
-
-    async fn record_queue_wait(&self) {
-        let queue_wait_ms = sqlx::query_scalar::<_, i64>(
-            "SELECT GREATEST(0, ((EXTRACT(EPOCH FROM (now() - COALESCE(attempt_at, created_at))) * 1000)::BIGINT)) FROM mq_msgs WHERE id = $1",
-        )
-            .bind(self.job.id())
-            .fetch_optional(self.job.pool())
-            .await;
-
-        let Ok(Some(queue_wait_ms)) = queue_wait_ms else {
-            return;
-        };
-
-        Span::current().record("queue_wait_ms", tracing::field::display(queue_wait_ms));
     }
 
     fn spawn_keep_alive(&self, mut interval: Duration) -> KeepAliveHandle {

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -38,8 +38,9 @@ const RESPAWN_ALL_OUTBOX_ID: Uuid = uuid!("00000000-0000-0000-0000-000000000003"
 pub struct JobRunners {
     // These handles are intentionally retained for process lifetime so each
     // runner task keeps running until the app shuts down.
-    pub account_main: JobRunnerHandle,
-    pub critical: JobRunnerHandle,
+    pub payout: JobRunnerHandle,
+    pub wallet_sync: JobRunnerHandle,
+    pub batch_finalization: JobRunnerHandle,
     pub maintenance: JobRunnerHandle,
 }
 
@@ -63,7 +64,7 @@ pub async fn start_job_runners(
 ) -> Result<JobRunners, JobError> {
     let runner_config = config.runners.clone();
 
-    let account_main_registry = build_job_registry(
+    let payout_registry = build_job_registry(
         config.clone(),
         blockchain_cfg.clone(),
         outbox.clone(),
@@ -80,20 +81,19 @@ pub async fn start_job_runners(
         fees_client.clone(),
     );
 
-    let account_main_concurrency =
-        normalize_concurrency("account_main", runner_config.account_main);
-    let account_main = account_main_registry
+    let payout_concurrency = normalize_concurrency("payout", runner_config.payout);
+    let payout = payout_registry
         .runner(pool)
-        .set_channel_names(&["account_main"])
+        .set_channel_names(&["payout"])
         .set_concurrency(
-            account_main_concurrency.min_concurrency,
-            account_main_concurrency.max_concurrency,
+            payout_concurrency.min_concurrency,
+            payout_concurrency.max_concurrency,
         )
         .set_keep_alive(false)
         .run()
         .await?;
 
-    let critical_registry = build_job_registry(
+    let wallet_sync_registry = build_job_registry(
         config.clone(),
         blockchain_cfg.clone(),
         outbox.clone(),
@@ -110,13 +110,43 @@ pub async fn start_job_runners(
         fees_client.clone(),
     );
 
-    let critical_concurrency = normalize_concurrency("critical", runner_config.critical);
-    let critical = critical_registry
+    let wallet_sync_concurrency = normalize_concurrency("wallet_sync", runner_config.wallet_sync);
+    let wallet_sync = wallet_sync_registry
+        .runner(pool)
+        .set_channel_names(&["wallet_sync"])
+        .set_concurrency(
+            wallet_sync_concurrency.min_concurrency,
+            wallet_sync_concurrency.max_concurrency,
+        )
+        .set_keep_alive(false)
+        .run()
+        .await?;
+
+    let batch_finalization_registry = build_job_registry(
+        config.clone(),
+        blockchain_cfg.clone(),
+        outbox.clone(),
+        wallets.clone(),
+        xpubs.clone(),
+        payout_queues.clone(),
+        batches.clone(),
+        signing_sessions.clone(),
+        payouts.clone(),
+        ledger.clone(),
+        utxos.clone(),
+        addresses.clone(),
+        signer_encryption_config.clone(),
+        fees_client.clone(),
+    );
+
+    let batch_finalization_concurrency =
+        normalize_concurrency("batch_finalization", runner_config.batch_finalization);
+    let batch_finalization = batch_finalization_registry
         .runner(pool)
         .set_channel_names(&["wallet_accounting", "batch_signing", "batch_broadcasting"])
         .set_concurrency(
-            critical_concurrency.min_concurrency,
-            critical_concurrency.max_concurrency,
+            batch_finalization_concurrency.min_concurrency,
+            batch_finalization_concurrency.max_concurrency,
         )
         .set_keep_alive(false)
         .run()
@@ -158,8 +188,9 @@ pub async fn start_job_runners(
         .await?;
 
     Ok(JobRunners {
-        account_main,
-        critical,
+        payout,
+        wallet_sync,
+        batch_finalization,
         maintenance,
     })
 }
@@ -380,7 +411,7 @@ pub async fn spawn_process_payout_queue(
     data: impl Into<ProcessPayoutQueueData>,
 ) -> Result<ProcessPayoutQueueData, JobError> {
     let data = data.into();
-    onto_account_main_channel(
+    onto_payout_channel(
         pool,
         data.account_id,
         Uuid::new_v4(),
@@ -572,7 +603,7 @@ pub async fn spawn_sync_all_wallets(
 
 #[instrument(name = "job.spawn_sync_wallet", skip_all, fields(error, error.level, error.message), err)]
 async fn spawn_sync_wallet(pool: &sqlx::PgPool, data: SyncWalletData) -> Result<(), JobError> {
-    onto_account_main_channel(pool, data.account_id, data.wallet_id, "sync_wallet", data).await?;
+    onto_wallet_sync_channel(pool, data.wallet_id, data.wallet_id, "sync_wallet", data).await?;
     Ok(())
 }
 
@@ -765,9 +796,9 @@ fn schedule_payout_queue_channel_arg(payout_queue_id: PayoutQueueId) -> String {
     format!("payout_queue_id:{payout_queue_id}")
 }
 
-async fn onto_account_main_channel<D: serde::Serialize>(
+async fn onto_wallet_sync_channel<D: serde::Serialize>(
     pool: &sqlx::PgPool,
-    account_id: AccountId,
+    wallet_id: WalletId,
     uuid: impl Into<Uuid>,
     name: &str,
     data: D,
@@ -777,8 +808,8 @@ async fn onto_account_main_channel<D: serde::Serialize>(
         match JobBuilder::new_with_id(uuid, name)
             .set_ordered(true)
             .set_retry_backoff(std::time::Duration::from_secs(2))
-            .set_channel_name("account_main")
-            .set_channel_args(&account_main_channel_arg(account_id))
+            .set_channel_name("wallet_sync")
+            .set_channel_args(&wallet_sync_channel_arg(wallet_id))
             .set_json(&data)
             .expect("Couldn't set json")
             .spawn(pool)
@@ -800,8 +831,47 @@ async fn onto_account_main_channel<D: serde::Serialize>(
     }
 }
 
-fn account_main_channel_arg(account_id: AccountId) -> String {
+async fn onto_payout_channel<D: serde::Serialize>(
+    pool: &sqlx::PgPool,
+    account_id: AccountId,
+    uuid: impl Into<Uuid>,
+    name: &str,
+    data: D,
+) -> Result<D, JobError> {
+    let uuid = uuid.into();
+    loop {
+        match JobBuilder::new_with_id(uuid, name)
+            .set_ordered(true)
+            .set_retry_backoff(std::time::Duration::from_secs(2))
+            .set_channel_name("payout")
+            .set_channel_args(&payout_channel_arg(account_id))
+            .set_json(&data)
+            .expect("Couldn't set json")
+            .spawn(pool)
+            .await
+        {
+            Err(sqlx::Error::Database(err)) if err.message().contains("duplicate key") => {
+                return Ok(data)
+            }
+            Err(sqlx::Error::Database(err)) if err.message().contains("after_message_id_fkey") => {
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                continue;
+            }
+            Err(e) => {
+                crate::tracing::insert_error_fields(tracing::Level::ERROR, &e);
+                return Err(JobError::from(e));
+            }
+            Ok(_) => return Ok(data),
+        }
+    }
+}
+
+fn payout_channel_arg(account_id: AccountId) -> String {
     format!("account_id:{account_id}")
+}
+
+fn wallet_sync_channel_arg(wallet_id: WalletId) -> String {
+    format!("wallet_id:{wallet_id}")
 }
 
 #[cfg(test)]

--- a/tests/e2e/bitcoind_sync.bats
+++ b/tests/e2e/bitcoind_sync.bats
@@ -33,7 +33,7 @@ teardown_file() {
 
   bitcoin_cli -regtest sendtoaddress ${bitcoind_signer_address} 1
 
-  for i in {1..30}; do
+  for i in {1..60}; do
     cache_wallet_balance
     [[ $(cached_pending_income) == 100000000 ]] && break
     sleep 1
@@ -50,7 +50,7 @@ teardown_file() {
 
   bitcoin_cli -generate 2
 
-  for i in {1..30}; do
+  for i in {1..60}; do
     cache_wallet_balance
     [[ $(cached_current_settled) == 100000000 ]] && break
     sleep 1
@@ -67,7 +67,7 @@ teardown_file() {
 @test "bitcoind_signer_sync: Detects outgoing transactions" {
   bitcoind_address=$(bitcoin_cli -regtest getnewaddress)
   bitcoin_signer_cli -regtest sendtoaddress "${bitcoind_address}" 0.5
-  for i in {1..30}; do
+  for i in {1..60}; do
     cache_wallet_balance
     [[ $(cached_pending_outgoing) == 50000000 ]] && break
     sleep 1
@@ -83,7 +83,7 @@ teardown_file() {
 
   bitcoin_cli -generate 1
 
-  for i in {1..30}; do
+  for i in {1..60}; do
     cache_wallet_balance
     [[ $(cached_current_settled) != 0 ]] && break
     sleep 1
@@ -118,7 +118,7 @@ teardown_file() {
     0.38 \
     ${bitcoind_address}
 
-  for i in {1..30}; do
+  for i in {1..60}; do
     cache_wallet_balance
     [[ $(cached_pending_outgoing) == 210000000 ]] && break
     sleep 1
@@ -127,7 +127,7 @@ teardown_file() {
   [[ $(cached_effective_settled) != 0 ]] || exit 1
 
   bitcoin_cli -generate 2
-  for i in {1..30}; do
+  for i in {1..60}; do
     cache_wallet_balance
     [[ $(cached_pending_outgoing) == 0 ]] && break
     sleep 1
@@ -159,7 +159,7 @@ teardown_file() {
       || exit 1
 
   bitcoin_cli -generate 1
-  for i in {1..30}; do
+  for i in {1..60}; do
     cache_wallet_balance
     [[ $(cached_pending_outgoing) == 0 ]] \
       && [[ $(cached_encumbered_fees) == 0 ]] \
@@ -185,7 +185,7 @@ teardown_file() {
     0.39 \
     ${bitcoind_address}
 
-  for i in {1..30}; do
+  for i in {1..60}; do
     cache_wallet_balance
     [[ $(cached_pending_outgoing) == 60000000 ]] && break
     sleep 1
@@ -194,7 +194,7 @@ teardown_file() {
   [[ $(cached_effective_settled) == 0 ]] || exit 1
 
   bitcoin_cli -generate 2
-  for i in {1..30}; do
+  for i in {1..60}; do
     cache_wallet_balance
     [[ $(cached_pending_outgoing) == 0 ]] && break
     sleep 1

--- a/tests/e2e/bria.docker.yml
+++ b/tests/e2e/bria.docker.yml
@@ -5,3 +5,6 @@ app:
   fees:
     mempool_space:
       url: http://mempool:8999
+  jobs:
+    sync_all_wallets_delay: 1
+    process_all_payout_queues_delay: 1

--- a/tests/e2e/bria.local.yml
+++ b/tests/e2e/bria.local.yml
@@ -5,3 +5,6 @@ app:
   fees:
     mempool_space:
       url: http://localhost:8999
+  jobs:
+    sync_all_wallets_delay: 1
+    process_all_payout_queues_delay: 1

--- a/tests/e2e/lnd_sync.bats
+++ b/tests/e2e/lnd_sync.bats
@@ -33,7 +33,7 @@ teardown_file() {
 
   bitcoin_cli -regtest sendtoaddress ${lnd_address} 1
 
-  for i in {1..30}; do
+  for i in {1..60}; do
     cache_wallet_balance
     [[ $(cached_pending_income) == 100000000 ]] && break
     sleep 1
@@ -50,7 +50,7 @@ teardown_file() {
 
   bitcoin_cli -generate 2
 
-  for i in {1..30}; do
+  for i in {1..60}; do
     cache_wallet_balance
     [[ $(cached_current_settled) == 100000000 ]] && break
     sleep 1
@@ -67,7 +67,7 @@ teardown_file() {
 @test "lnd_sync: Detects outgoing transactions" {
   bitcoind_address=$(bitcoin_cli -regtest getnewaddress)
   lnd_cli sendcoins --addr=${bitcoind_address} --amt=50000000
-  for i in {1..30}; do
+  for i in {1..60}; do
     cache_wallet_balance
     [[ $(cached_pending_outgoing) == 50000000 ]] && break
     sleep 1
@@ -83,7 +83,7 @@ teardown_file() {
 
   bitcoin_cli -generate 1
 
-  for i in {1..30}; do
+  for i in {1..60}; do
     cache_wallet_balance
     [[ $(cached_current_settled) != 0 ]] && break
     sleep 1
@@ -110,7 +110,7 @@ teardown_file() {
   bitcoind_address=$(bitcoin_cli -regtest getnewaddress)
   lnd_cli sendcoins --addr=${bitcoind_address} --amt=210000000 --min_confs 0
 
-  for i in {1..30}; do
+  for i in {1..60}; do
     cache_wallet_balance
     [[ $(cached_pending_outgoing) == 210000000 ]] && break
     sleep 1
@@ -119,7 +119,7 @@ teardown_file() {
   [[ $(cached_effective_settled) != 0 ]] || exit 1
 
   bitcoin_cli -generate 2
-  for i in {1..30}; do
+  for i in {1..60}; do
     cache_wallet_balance
     [[ $(cached_pending_outgoing) == 0 ]] && break
     sleep 1
@@ -134,7 +134,7 @@ teardown_file() {
   lnd_cli sendcoins --addr=${bitcoind_address} --sweepall
   bitcoin_cli -generate 1
 
-  for i in {1..30}; do
+  for i in {1..60}; do
     cache_wallet_balance
     [[ $(cached_encumbered_fees) == 0 ]] && break
     sleep 1
@@ -149,7 +149,7 @@ teardown_file() {
   bitcoind_address=$(bitcoin_cli -regtest getnewaddress)
   lnd_cli sendcoins --addr=${bitcoind_address} --amt=60000000 --min_confs 0
 
-  for i in {1..30}; do
+  for i in {1..60}; do
     cache_wallet_balance
     [[ $(cached_pending_outgoing) == 60000000 ]] && break
     sleep 1
@@ -158,7 +158,7 @@ teardown_file() {
   [[ $(cached_effective_settled) == 0 ]] || exit 1
 
   bitcoin_cli -generate 2
-  for i in {1..30}; do
+  for i in {1..60}; do
     cache_wallet_balance
     [[ $(cached_pending_outgoing) == 0 ]] && break
     sleep 1

--- a/tests/e2e/multisig_payout.bats
+++ b/tests/e2e/multisig_payout.bats
@@ -41,8 +41,8 @@ teardown_file() {
   bitcoin_cli -regtest sendtoaddress ${bitcoind_signer_address} 1
 
   for i in {1..60}; do
-  n_change_utxos=$(bria_cmd list-utxos -w multisig | jq '.keychains[0].utxos | map(select(.changeOutput == true)) | length')
-    [[ "${n_utxos}" == "1" ]] && break
+    n_change_utxos=$(bria_cmd list-utxos -w multisig | jq '.keychains[0].utxos | map(select(.changeOutput == true)) | length')
+    [[ "${n_change_utxos}" == "1" ]] && break
     sleep 1
   done
 

--- a/tests/e2e/multisig_payout.bats
+++ b/tests/e2e/multisig_payout.bats
@@ -24,7 +24,7 @@ teardown_file() {
 
   bitcoin_cli -regtest sendtoaddress ${bria_address} 1
 
-  for i in {1..30}; do
+  for i in {1..60}; do
     n_utxos=$(bria_cmd list-utxos -w multisig | jq '.keychains[0].utxos | length')
     [[ "${n_utxos}" == "1" ]] && break
     sleep 1
@@ -40,7 +40,7 @@ teardown_file() {
 
   bitcoin_cli -regtest sendtoaddress ${bitcoind_signer_address} 1
 
-  for i in {1..30}; do
+  for i in {1..60}; do
   n_change_utxos=$(bria_cmd list-utxos -w multisig | jq '.keychains[0].utxos | map(select(.changeOutput == true)) | length')
     [[ "${n_utxos}" == "1" ]] && break
     sleep 1

--- a/tests/e2e/outbox.bats
+++ b/tests/e2e/outbox.bats
@@ -17,7 +17,7 @@ teardown_file() {
 @test "outbox: Emits utxo_dropped event" {
   bria_address=$(bria_cmd new-address -w default | jq -r '.address')
   bitcoin_cli -regtest sendtoaddress ${bria_address} 1
-  for i in {1..30}; do
+  for i in {1..60}; do
     n_utxos=$(bria_cmd list-utxos -w default | jq '.keychains[0].utxos | length')
     [[ "${n_utxos}" == "1" ]] && break
     sleep 1

--- a/tests/e2e/payout.bats
+++ b/tests/e2e/payout.bats
@@ -50,7 +50,7 @@ teardown_file() {
   bitcoin_cli -regtest sendtoaddress ${bria_address} 1
   bitcoin_cli -regtest sendtoaddress ${bria_address} 1
 
-  for i in {1..30}; do
+  for i in {1..60}; do
    n_utxos=$(bria_cmd list-utxos -w default | jq '.keychains[0].utxos | length')
     [[ "${n_utxos}" == "3" ]] && break
     sleep 1
@@ -75,7 +75,7 @@ teardown_file() {
 @test "payout: Settling income means batch is created" {
   bitcoin_cli -generate 20
 
-  for i in {1..30}; do
+  for i in {1..60}; do
     utxo_height=$(bria_cmd list-utxos -w default | jq '.keychains[0].utxos[0].blockHeight')
     [[ "${utxo_height}" != "null" ]] && break;
     sleep 1
@@ -537,7 +537,7 @@ teardown_file() {
   destination="bcrt1q208tuy5rd3kvy8xdpv6yrczg7f3mnlk3lql7ej"
   payout_id=$(bria_cmd submit-payout -w default --queue-name large-tx-queue --destination ${destination} --amount 125000000 | jq -r '.id')
 
-  for i in {1..30}; do
+  for i in {1..60}; do
     cache_wallet_balance
     encumbered=$(cached_encumbered_outgoing)
     echo "Encumbered outgoing: ${encumbered}"


### PR DESCRIPTION
## Summary

Separate `sync_wallet` execution from payout processing to eliminate head-of-line blocking where large wallet syncs delay payout jobs.

- Add dedicated `wallet_sync` runner with per-wallet ordered channels
- Reroute `spawn_sync_wallet` from payout channel to `wallet_sync` channel
- Rename runners for clarity: `account_main` → `payout`, `critical` → `batch_finalization`
- Add observability span field: `execution_duration_ms`