### PR TITLE
feat: add wallet sync progress tracing with sync run correlation

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1124,6 +1124,7 @@ async fn run_cmd(
     for handle in handles {
         handle.abort();
     }
+    crate::tracing::shutdown_tracer();
 
     reason
 }

--- a/src/job/sync_wallet.rs
+++ b/src/job/sync_wallet.rs
@@ -135,7 +135,7 @@ pub async fn execute(
 
         info!(%sync_run_id, %keychain_id, "wallet sync phase started");
         match keychain_wallet
-            .sync(blockchain, data.wallet_id, sync_run_id.clone())
+            .sync_with_context(blockchain, data.wallet_id, sync_run_id.clone())
             .await
         {
             Ok(()) => info!(%sync_run_id, %keychain_id, "wallet sync phase completed"),

--- a/src/job/sync_wallet.rs
+++ b/src/job/sync_wallet.rs
@@ -24,7 +24,7 @@ use crate::{
     ledger::*,
     primitives::*,
     utxo::{error::UtxoError, Utxos, WalletUtxo},
-    wallet::*,
+    wallet::{SyncProgressContext, *},
 };
 use std::collections::HashMap;
 
@@ -134,8 +134,10 @@ pub async fn execute(
         span.record("current_height", current_height);
 
         info!(%sync_run_id, %keychain_id, "wallet sync phase started");
+        let progress_context =
+            SyncProgressContext::with_sync_run_id(data.wallet_id, keychain_id, sync_run_id.clone());
         match keychain_wallet
-            .sync_with_context(blockchain, data.wallet_id, sync_run_id.clone())
+            .sync(blockchain, Some(progress_context))
             .await
         {
             Ok(()) => info!(%sync_run_id, %keychain_id, "wallet sync phase completed"),

--- a/src/job/sync_wallet.rs
+++ b/src/job/sync_wallet.rs
@@ -6,6 +6,7 @@ use bdk::{
 use electrum_client::{Client, ConfigBuilder};
 use serde::{Deserialize, Serialize};
 use tracing::{info, instrument};
+use uuid::Uuid;
 
 use super::error::JobError;
 use crate::{
@@ -85,6 +86,8 @@ const MAX_TXS_PER_SYNC: usize = 200;
     name = "job.sync_wallet",
     skip(pool, wallets, batches, bria_utxos, bria_addresses, ledger),
     fields(
+        sync_run_id,
+        keychain_id,
         n_pending_utxos,
         n_confirmed_utxos,
         n_found_txs,
@@ -105,8 +108,10 @@ pub async fn execute(
     data: SyncWalletData,
     fees_client: FeesClient,
 ) -> Result<(bool, SyncWalletData), JobError> {
-    info!("Starting sync_wallet job: {:?}", data);
+    let sync_run_id = Uuid::new_v4().to_string();
+    info!(%sync_run_id, "Starting sync_wallet job: {:?}", data);
     let span = tracing::Span::current();
+    span.record("sync_run_id", tracing::field::display(&sync_run_id));
 
     let wallet = wallets.find_by_id(data.wallet_id).await?;
     let mut trackers = InstrumentationTrackers::new();
@@ -123,11 +128,22 @@ pub async fn execute(
         let fees_to_encumber =
             fees::fees_to_encumber(&fees_client, keychain_wallet.max_satisfaction_weight()).await?;
         let keychain_id = keychain_wallet.keychain_id;
+        span.record("keychain_id", tracing::field::display(keychain_id));
 
         let (blockchain, current_height) = init_electrum(&deps.blockchain_cfg.electrum_url).await?;
         span.record("current_height", current_height);
 
-        keychain_wallet.sync(blockchain).await?;
+        info!(%sync_run_id, %keychain_id, "wallet sync phase started");
+        match keychain_wallet
+            .sync(blockchain, data.wallet_id, sync_run_id.clone())
+            .await
+        {
+            Ok(()) => info!(%sync_run_id, %keychain_id, "wallet sync phase completed"),
+            Err(err) => {
+                info!(%sync_run_id, %keychain_id, error = %err, "wallet sync phase failed");
+                return Err(err.into());
+            }
+        }
 
         let bdk_txs = Transactions::new(keychain_id, pool.clone());
         let bdk_utxos = BdkUtxos::new(keychain_id, pool.clone());

--- a/src/job/sync_wallet.rs
+++ b/src/job/sync_wallet.rs
@@ -6,7 +6,6 @@ use bdk::{
 use electrum_client::{Client, ConfigBuilder};
 use serde::{Deserialize, Serialize};
 use tracing::{error, info, instrument};
-use uuid::Uuid;
 
 use super::error::JobError;
 use crate::{
@@ -107,7 +106,8 @@ pub async fn execute(
     data: SyncWalletData,
     fees_client: FeesClient,
 ) -> Result<(bool, SyncWalletData), JobError> {
-    let sync_run_id = Uuid::new_v4().to_string();
+    let progress_context = SyncProgressContext::new();
+    let sync_run_id = progress_context.sync_run_id.clone();
     info!(%sync_run_id, "Starting sync_wallet job: {:?}", data);
     let span = tracing::Span::current();
     span.record("sync_run_id", tracing::field::display(&sync_run_id));
@@ -132,9 +132,10 @@ pub async fn execute(
         span.record("current_height", current_height);
 
         info!(%sync_run_id, %keychain_id, "wallet sync phase started");
-        let progress_context =
-            SyncProgressContext::with_sync_run_id(data.wallet_id, sync_run_id.clone());
-        match keychain_wallet.sync(blockchain, progress_context).await {
+        match keychain_wallet
+            .sync(blockchain, progress_context.clone())
+            .await
+        {
             Ok(()) => info!(%sync_run_id, %keychain_id, "wallet sync phase completed"),
             Err(err) => {
                 error!(%sync_run_id, %keychain_id, error = %err, "wallet sync phase failed");

--- a/src/job/sync_wallet.rs
+++ b/src/job/sync_wallet.rs
@@ -133,7 +133,7 @@ pub async fn execute(
 
         info!(%sync_run_id, %keychain_id, "wallet sync phase started");
         let progress_context =
-            SyncProgressContext::with_sync_run_id(data.wallet_id, keychain_id, sync_run_id.clone());
+            SyncProgressContext::with_sync_run_id(data.wallet_id, sync_run_id.clone());
         match keychain_wallet.sync(blockchain, progress_context).await {
             Ok(()) => info!(%sync_run_id, %keychain_id, "wallet sync phase completed"),
             Err(err) => {

--- a/src/job/sync_wallet.rs
+++ b/src/job/sync_wallet.rs
@@ -87,7 +87,6 @@ const MAX_TXS_PER_SYNC: usize = 200;
     skip(pool, wallets, batches, bria_utxos, bria_addresses, ledger),
     fields(
         sync_run_id,
-        keychain_id,
         n_pending_utxos,
         n_confirmed_utxos,
         n_found_txs,
@@ -128,7 +127,6 @@ pub async fn execute(
         let fees_to_encumber =
             fees::fees_to_encumber(&fees_client, keychain_wallet.max_satisfaction_weight()).await?;
         let keychain_id = keychain_wallet.keychain_id;
-        span.record("keychain_id", tracing::field::display(keychain_id));
 
         let (blockchain, current_height) = init_electrum(&deps.blockchain_cfg.electrum_url).await?;
         span.record("current_height", current_height);
@@ -136,10 +134,7 @@ pub async fn execute(
         info!(%sync_run_id, %keychain_id, "wallet sync phase started");
         let progress_context =
             SyncProgressContext::with_sync_run_id(data.wallet_id, keychain_id, sync_run_id.clone());
-        match keychain_wallet
-            .sync(blockchain, Some(progress_context))
-            .await
-        {
+        match keychain_wallet.sync(blockchain, progress_context).await {
             Ok(()) => info!(%sync_run_id, %keychain_id, "wallet sync phase completed"),
             Err(err) => {
                 error!(%sync_run_id, %keychain_id, error = %err, "wallet sync phase failed");

--- a/src/job/sync_wallet.rs
+++ b/src/job/sync_wallet.rs
@@ -5,7 +5,7 @@ use bdk::{
 };
 use electrum_client::{Client, ConfigBuilder};
 use serde::{Deserialize, Serialize};
-use tracing::{info, instrument};
+use tracing::{error, info, instrument};
 use uuid::Uuid;
 
 use super::error::JobError;
@@ -142,7 +142,7 @@ pub async fn execute(
         {
             Ok(()) => info!(%sync_run_id, %keychain_id, "wallet sync phase completed"),
             Err(err) => {
-                info!(%sync_run_id, %keychain_id, error = %err, "wallet sync phase failed");
+                error!(%sync_run_id, %keychain_id, error = %err, "wallet sync phase failed");
                 return Err(err.into());
             }
         }

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -45,7 +45,17 @@ pub fn init_tracer(config: TracingConfig) -> anyhow::Result<()> {
         .build()?;
 
     let sampler = match config.sample_ratio {
-        Some(ratio) if ratio <= 0.0 => Sampler::AlwaysOff,
+        Some(ratio) if !ratio.is_finite() => {
+            return Err(anyhow::anyhow!(
+                "Invalid tracing.sample_ratio: {ratio}. Expected a finite value in [0.0, 1.0]"
+            ));
+        }
+        Some(ratio) if !(0.0..=1.0).contains(&ratio) => {
+            return Err(anyhow::anyhow!(
+                "Invalid tracing.sample_ratio: {ratio}. Expected value in [0.0, 1.0]"
+            ));
+        }
+        Some(0.0) => Sampler::AlwaysOff,
         Some(ratio) if ratio < 1.0 => {
             Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(ratio)))
         }

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -1,5 +1,5 @@
 use opentelemetry::trace::TracerProvider as _;
-use opentelemetry::{propagation::TextMapPropagator, KeyValue};
+use opentelemetry::{global, KeyValue};
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::trace::{Sampler, TracerProvider};
 use opentelemetry_sdk::{propagation::TraceContextPropagator, Resource};
@@ -18,6 +18,8 @@ pub struct TracingConfig {
     host: String,
     port: u16,
     service_name: String,
+    #[serde(default)]
+    sample_ratio: Option<f64>,
 }
 
 impl Default for TracingConfig {
@@ -26,6 +28,7 @@ impl Default for TracingConfig {
             host: "localhost".to_string(),
             port: 4317,
             service_name: "bria-dev".to_string(),
+            sample_ratio: None,
         }
     }
 }
@@ -34,21 +37,31 @@ pub fn init_tracer(config: TracingConfig) -> anyhow::Result<()> {
     let tracing_endpoint = format!("http://{}:{}", config.host, config.port);
     let service_name = config.service_name;
     println!("Sending traces to {tracing_endpoint}");
+    global::set_text_map_propagator(TraceContextPropagator::new());
 
     let exporter = opentelemetry_otlp::SpanExporter::builder()
         .with_tonic()
         .with_endpoint(tracing_endpoint)
         .build()?;
 
+    let sampler = match config.sample_ratio {
+        Some(ratio) if ratio <= 0.0 => Sampler::AlwaysOff,
+        Some(ratio) if ratio < 1.0 => {
+            Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(ratio)))
+        }
+        _ => Sampler::AlwaysOn,
+    };
+
     let provider = TracerProvider::builder()
         .with_batch_exporter(exporter, opentelemetry_sdk::runtime::Tokio)
-        .with_sampler(Sampler::AlwaysOn)
+        .with_sampler(sampler)
         .with_resource(Resource::new(vec![KeyValue::new(
             "service.name",
             service_name.clone(),
         )]))
         .build();
-    let tracer = provider.tracer(service_name);
+    let tracer = provider.tracer(service_name.clone());
+    global::set_tracer_provider(provider);
 
     let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
 
@@ -67,16 +80,20 @@ pub fn init_tracer(config: TracingConfig) -> anyhow::Result<()> {
 
 pub fn extract_tracing_data() -> HashMap<String, String> {
     let mut tracing_data = HashMap::new();
-    let propagator = TraceContextPropagator::new();
     let context = Span::current().context();
-    propagator.inject_context(&context, &mut tracing_data);
+    global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(&context, &mut tracing_data);
+    });
     tracing_data
 }
 
 pub fn inject_tracing_data(span: &Span, tracing_data: &HashMap<String, String>) {
-    let propagator = TraceContextPropagator::new();
-    let context = propagator.extract(tracing_data);
+    let context = global::get_text_map_propagator(|propagator| propagator.extract(tracing_data));
     span.set_parent(context);
+}
+
+pub fn shutdown_tracer() {
+    global::shutdown_tracer_provider();
 }
 
 pub fn insert_error_fields(level: tracing::Level, error: impl std::fmt::Display) {

--- a/src/wallet/entity.rs
+++ b/src/wallet/entity.rs
@@ -84,16 +84,16 @@ impl Wallet {
 
     pub fn current_keychain_wallet(&self, pool: &sqlx::PgPool) -> KeychainWallet {
         let (id, cfg) = self.iter_keychains().next().expect("No current keychain");
-        KeychainWallet::new(pool.clone(), self.network, *id, cfg.clone())
+        KeychainWallet::new(pool.clone(), self.network, self.id, *id, cfg.clone())
     }
 
     pub fn deprecated_keychain_wallets(
         &self,
         pool: sqlx::PgPool,
     ) -> impl Iterator<Item = KeychainWallet> + '_ {
-        self.iter_keychains()
-            .skip(1)
-            .map(move |(id, cfg)| KeychainWallet::new(pool.clone(), self.network, *id, cfg.clone()))
+        self.iter_keychains().skip(1).map(move |(id, cfg)| {
+            KeychainWallet::new(pool.clone(), self.network, self.id, *id, cfg.clone())
+        })
     }
 
     pub fn xpubs_for_keychains<'a>(

--- a/src/wallet/keychain/wallet.rs
+++ b/src/wallet/keychain/wallet.rs
@@ -33,23 +33,20 @@ pub struct KeychainWallet {
 
 #[derive(Debug, Clone)]
 pub struct SyncProgressContext {
-    pub wallet_id: WalletId,
     pub sync_run_id: String,
 }
 
 impl SyncProgressContext {
-    pub fn new(wallet_id: WalletId) -> Self {
+    pub fn new() -> Self {
         Self {
-            wallet_id,
             sync_run_id: Uuid::new_v4().to_string(),
         }
     }
+}
 
-    pub fn with_sync_run_id(wallet_id: WalletId, sync_run_id: String) -> Self {
-        Self {
-            wallet_id,
-            sync_run_id,
-        }
+impl Default for SyncProgressContext {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -69,14 +66,16 @@ struct ProgressState {
 #[derive(Debug)]
 struct TracingBdkProgress {
     context: SyncProgressContext,
+    wallet_id: WalletId,
     keychain_id: KeychainId,
     state: Mutex<ProgressState>,
 }
 
 impl TracingBdkProgress {
-    fn new(context: SyncProgressContext, keychain_id: KeychainId) -> Self {
+    fn new(context: SyncProgressContext, wallet_id: WalletId, keychain_id: KeychainId) -> Self {
         Self {
             context,
+            wallet_id,
             keychain_id,
             state: Mutex::new(ProgressState {
                 last_bucket: None,
@@ -93,7 +92,7 @@ impl Progress for TracingBdkProgress {
             Err(poisoned) => {
                 tracing::warn!(
                     sync_run_id = %self.context.sync_run_id,
-                    wallet_id = %self.context.wallet_id,
+                    wallet_id = %self.wallet_id,
                     keychain_id = %self.keychain_id,
                     "bdk progress state mutex poisoned; recovering"
                 );
@@ -112,7 +111,7 @@ impl Progress for TracingBdkProgress {
 
         tracing::info!(
             sync_run_id = %self.context.sync_run_id,
-            wallet_id = %self.context.wallet_id,
+            wallet_id = %self.wallet_id,
             keychain_id = %self.keychain_id,
             progress_pct = progress,
             progress_message = message.as_deref().unwrap_or(""),
@@ -230,6 +229,7 @@ impl KeychainWallet {
         context: SyncProgressContext,
     ) -> Result<(), BdkError> {
         let sync_span = tracing::Span::current();
+        let wallet_id = self.wallet_id;
         let keychain_id = self.keychain_id;
         self.with_wallet(move |wallet| {
             let _span_guard = sync_span.enter();
@@ -244,7 +244,7 @@ impl KeychainWallet {
             let max_last_index = last_external.max(last_internal);
 
             let _ = wallet.ensure_addresses_cached(max_last_index.saturating_add(1))?;
-            let progress = TracingBdkProgress::new(context, keychain_id);
+            let progress = TracingBdkProgress::new(context, wallet_id, keychain_id);
             wallet.sync(
                 &blockchain,
                 SyncOptions {

--- a/src/wallet/keychain/wallet.rs
+++ b/src/wallet/keychain/wallet.rs
@@ -88,7 +88,18 @@ impl TracingBdkProgress {
 
 impl Progress for TracingBdkProgress {
     fn update(&self, progress: f32, message: Option<String>) -> Result<(), bdk::Error> {
-        let mut state = self.state.lock().expect("bdk progress mutex poisoned");
+        let mut state = match self.state.lock() {
+            Ok(state) => state,
+            Err(poisoned) => {
+                tracing::warn!(
+                    sync_run_id = %self.context.sync_run_id,
+                    wallet_id = %self.context.wallet_id,
+                    keychain_id = %self.context.keychain_id,
+                    "bdk progress state mutex poisoned; recovering"
+                );
+                poisoned.into_inner()
+            }
+        };
         let elapsed = state.last_emit_at.elapsed();
 
         if !should_emit_progress(state.last_bucket, progress, elapsed) {

--- a/src/wallet/keychain/wallet.rs
+++ b/src/wallet/keychain/wallet.rs
@@ -188,6 +188,15 @@ impl KeychainWallet {
     pub async fn sync<B: WalletSync + GetHeight + Send + Sync + 'static>(
         &self,
         blockchain: B,
+    ) -> Result<(), BdkError> {
+        self.sync_with_context(blockchain, WalletId::new(), String::from("unknown"))
+            .await
+    }
+
+    #[instrument(name = "keychain_wallet.sync_with_context", skip_all)]
+    pub async fn sync_with_context<B: WalletSync + GetHeight + Send + Sync + 'static>(
+        &self,
+        blockchain: B,
         wallet_id: WalletId,
         sync_run_id: String,
     ) -> Result<(), BdkError> {

--- a/src/wallet/keychain/wallet.rs
+++ b/src/wallet/keychain/wallet.rs
@@ -7,6 +7,7 @@ use bdk::{
 use sqlx::PgPool;
 use std::{sync::Mutex, time::Duration};
 use tracing::instrument;
+use uuid::Uuid;
 
 use super::config::*;
 use crate::{
@@ -29,6 +30,35 @@ pub struct KeychainWallet {
     config: KeychainConfig,
 }
 
+#[derive(Debug, Clone)]
+pub struct SyncProgressContext {
+    pub wallet_id: WalletId,
+    pub keychain_id: KeychainId,
+    pub sync_run_id: String,
+}
+
+impl SyncProgressContext {
+    pub fn new(wallet_id: WalletId, keychain_id: KeychainId) -> Self {
+        Self {
+            wallet_id,
+            keychain_id,
+            sync_run_id: Uuid::new_v4().to_string(),
+        }
+    }
+
+    pub fn with_sync_run_id(
+        wallet_id: WalletId,
+        keychain_id: KeychainId,
+        sync_run_id: String,
+    ) -> Self {
+        Self {
+            wallet_id,
+            keychain_id,
+            sync_run_id,
+        }
+    }
+}
+
 const PROGRESS_BUCKET_SIZE_PCT: u8 = 10;
 const PROGRESS_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
 
@@ -40,18 +70,14 @@ struct ProgressState {
 
 #[derive(Debug)]
 struct TracingBdkProgress {
-    wallet_id: WalletId,
-    keychain_id: KeychainId,
-    sync_run_id: String,
+    context: SyncProgressContext,
     state: Mutex<ProgressState>,
 }
 
 impl TracingBdkProgress {
-    fn new(wallet_id: WalletId, keychain_id: KeychainId, sync_run_id: String) -> Self {
+    fn new(context: SyncProgressContext) -> Self {
         Self {
-            wallet_id,
-            keychain_id,
-            sync_run_id,
+            context,
             state: Mutex::new(ProgressState {
                 last_bucket: None,
                 last_emit_at: std::time::Instant::now(),
@@ -74,9 +100,9 @@ impl Progress for TracingBdkProgress {
         state.last_emit_at = std::time::Instant::now();
 
         tracing::info!(
-            sync_run_id = %self.sync_run_id,
-            wallet_id = %self.wallet_id,
-            keychain_id = %self.keychain_id,
+            sync_run_id = %self.context.sync_run_id,
+            wallet_id = %self.context.wallet_id,
+            keychain_id = %self.context.keychain_id,
             progress_pct = progress,
             progress_message = message.as_deref().unwrap_or(""),
             "wallet sync progress"
@@ -188,20 +214,11 @@ impl KeychainWallet {
     pub async fn sync<B: WalletSync + GetHeight + Send + Sync + 'static>(
         &self,
         blockchain: B,
-    ) -> Result<(), BdkError> {
-        self.sync_with_context(blockchain, WalletId::new(), String::from("unknown"))
-            .await
-    }
-
-    #[instrument(name = "keychain_wallet.sync_with_context", skip_all)]
-    pub async fn sync_with_context<B: WalletSync + GetHeight + Send + Sync + 'static>(
-        &self,
-        blockchain: B,
-        wallet_id: WalletId,
-        sync_run_id: String,
+        context: Option<SyncProgressContext>,
     ) -> Result<(), BdkError> {
         let sync_span = tracing::Span::current();
-        let keychain_id = self.keychain_id;
+        let progress_context =
+            context.unwrap_or_else(|| SyncProgressContext::new(WalletId::new(), self.keychain_id));
         self.with_wallet(move |wallet| {
             let _span_guard = sync_span.enter();
             let last_external = wallet
@@ -215,7 +232,7 @@ impl KeychainWallet {
             let max_last_index = last_external.max(last_internal);
 
             let _ = wallet.ensure_addresses_cached(max_last_index.saturating_add(1))?;
-            let progress = TracingBdkProgress::new(wallet_id, keychain_id, sync_run_id);
+            let progress = TracingBdkProgress::new(progress_context);
             wallet.sync(
                 &blockchain,
                 SyncOptions {

--- a/src/wallet/keychain/wallet.rs
+++ b/src/wallet/keychain/wallet.rs
@@ -62,6 +62,10 @@ impl SyncProgressContext {
 const PROGRESS_BUCKET_SIZE_PCT: u8 = 10;
 const PROGRESS_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
 
+const fn completion_bucket() -> u8 {
+    100 / PROGRESS_BUCKET_SIZE_PCT
+}
+
 #[derive(Debug)]
 struct ProgressState {
     last_bucket: Option<u8>,
@@ -124,7 +128,7 @@ impl Progress for TracingBdkProgress {
 }
 
 fn progress_bucket(progress: f32) -> u8 {
-    (progress.clamp(0.0, 100.0) as u8 / PROGRESS_BUCKET_SIZE_PCT).min(10)
+    (progress.clamp(0.0, 100.0) as u8 / PROGRESS_BUCKET_SIZE_PCT).min(completion_bucket())
 }
 
 fn should_emit_progress(
@@ -142,7 +146,7 @@ fn should_emit_progress(
     }
 
     if progress >= 100.0 {
-        return true;
+        return last_bucket != Some(completion_bucket());
     }
 
     elapsed_since_last_emit >= PROGRESS_HEARTBEAT_INTERVAL
@@ -225,11 +229,9 @@ impl KeychainWallet {
     pub async fn sync<B: WalletSync + GetHeight + Send + Sync + 'static>(
         &self,
         blockchain: B,
-        context: Option<SyncProgressContext>,
+        context: SyncProgressContext,
     ) -> Result<(), BdkError> {
         let sync_span = tracing::Span::current();
-        let progress_context =
-            context.unwrap_or_else(|| SyncProgressContext::new(WalletId::new(), self.keychain_id));
         self.with_wallet(move |wallet| {
             let _span_guard = sync_span.enter();
             let last_external = wallet
@@ -243,7 +245,7 @@ impl KeychainWallet {
             let max_last_index = last_external.max(last_internal);
 
             let _ = wallet.ensure_addresses_cached(max_last_index.saturating_add(1))?;
-            let progress = TracingBdkProgress::new(progress_context);
+            let progress = TracingBdkProgress::new(context);
             wallet.sync(
                 &blockchain,
                 SyncOptions {
@@ -333,7 +335,12 @@ mod tests {
 
     #[test]
     fn emits_at_completion_even_without_bucket_change() {
-        assert!(should_emit_progress(
+        assert!(should_emit_progress(Some(9), 100.0, Duration::from_secs(1)));
+    }
+
+    #[test]
+    fn does_not_repeat_completion_event() {
+        assert!(!should_emit_progress(
             Some(10),
             100.0,
             Duration::from_secs(1)

--- a/src/wallet/keychain/wallet.rs
+++ b/src/wallet/keychain/wallet.rs
@@ -24,6 +24,7 @@ pub trait BdkWalletVisitor: Sized + Send + 'static {
 }
 
 pub struct KeychainWallet {
+    pub wallet_id: WalletId,
     pub keychain_id: KeychainId,
     pool: PgPool,
     network: Network,
@@ -33,27 +34,20 @@ pub struct KeychainWallet {
 #[derive(Debug, Clone)]
 pub struct SyncProgressContext {
     pub wallet_id: WalletId,
-    pub keychain_id: KeychainId,
     pub sync_run_id: String,
 }
 
 impl SyncProgressContext {
-    pub fn new(wallet_id: WalletId, keychain_id: KeychainId) -> Self {
+    pub fn new(wallet_id: WalletId) -> Self {
         Self {
             wallet_id,
-            keychain_id,
             sync_run_id: Uuid::new_v4().to_string(),
         }
     }
 
-    pub fn with_sync_run_id(
-        wallet_id: WalletId,
-        keychain_id: KeychainId,
-        sync_run_id: String,
-    ) -> Self {
+    pub fn with_sync_run_id(wallet_id: WalletId, sync_run_id: String) -> Self {
         Self {
             wallet_id,
-            keychain_id,
             sync_run_id,
         }
     }
@@ -75,13 +69,15 @@ struct ProgressState {
 #[derive(Debug)]
 struct TracingBdkProgress {
     context: SyncProgressContext,
+    keychain_id: KeychainId,
     state: Mutex<ProgressState>,
 }
 
 impl TracingBdkProgress {
-    fn new(context: SyncProgressContext) -> Self {
+    fn new(context: SyncProgressContext, keychain_id: KeychainId) -> Self {
         Self {
             context,
+            keychain_id,
             state: Mutex::new(ProgressState {
                 last_bucket: None,
                 last_emit_at: std::time::Instant::now(),
@@ -98,7 +94,7 @@ impl Progress for TracingBdkProgress {
                 tracing::warn!(
                     sync_run_id = %self.context.sync_run_id,
                     wallet_id = %self.context.wallet_id,
-                    keychain_id = %self.context.keychain_id,
+                    keychain_id = %self.keychain_id,
                     "bdk progress state mutex poisoned; recovering"
                 );
                 poisoned.into_inner()
@@ -117,7 +113,7 @@ impl Progress for TracingBdkProgress {
         tracing::info!(
             sync_run_id = %self.context.sync_run_id,
             wallet_id = %self.context.wallet_id,
-            keychain_id = %self.context.keychain_id,
+            keychain_id = %self.keychain_id,
             progress_pct = progress,
             progress_message = message.as_deref().unwrap_or(""),
             "wallet sync progress"
@@ -156,10 +152,12 @@ impl KeychainWallet {
     pub fn new(
         pool: PgPool,
         network: Network,
+        wallet_id: WalletId,
         keychain_id: KeychainId,
         descriptors: KeychainConfig,
     ) -> Self {
         Self {
+            wallet_id,
             pool,
             network,
             keychain_id,
@@ -232,6 +230,7 @@ impl KeychainWallet {
         context: SyncProgressContext,
     ) -> Result<(), BdkError> {
         let sync_span = tracing::Span::current();
+        let keychain_id = self.keychain_id;
         self.with_wallet(move |wallet| {
             let _span_guard = sync_span.enter();
             let last_external = wallet
@@ -245,7 +244,7 @@ impl KeychainWallet {
             let max_last_index = last_external.max(last_internal);
 
             let _ = wallet.ensure_addresses_cached(max_last_index.saturating_add(1))?;
-            let progress = TracingBdkProgress::new(context);
+            let progress = TracingBdkProgress::new(context, keychain_id);
             wallet.sync(
                 &blockchain,
                 SyncOptions {

--- a/src/wallet/keychain/wallet.rs
+++ b/src/wallet/keychain/wallet.rs
@@ -1,10 +1,11 @@
 use bdk::{
-    blockchain::{GetHeight, WalletSync},
+    blockchain::{GetHeight, Progress, WalletSync},
     database::{BatchDatabase, Database},
-    wallet::{signer::SignOptions, AddressIndex},
+    wallet::{signer::SignOptions, AddressIndex, SyncOptions},
     Wallet,
 };
 use sqlx::PgPool;
+use std::{sync::Mutex, time::Duration};
 use tracing::instrument;
 
 use super::config::*;
@@ -26,6 +27,88 @@ pub struct KeychainWallet {
     pool: PgPool,
     network: Network,
     config: KeychainConfig,
+}
+
+const PROGRESS_BUCKET_SIZE_PCT: u8 = 10;
+const PROGRESS_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+
+#[derive(Debug)]
+struct ProgressState {
+    last_bucket: Option<u8>,
+    last_emit_at: std::time::Instant,
+}
+
+#[derive(Debug)]
+struct TracingBdkProgress {
+    wallet_id: WalletId,
+    keychain_id: KeychainId,
+    sync_run_id: String,
+    state: Mutex<ProgressState>,
+}
+
+impl TracingBdkProgress {
+    fn new(wallet_id: WalletId, keychain_id: KeychainId, sync_run_id: String) -> Self {
+        Self {
+            wallet_id,
+            keychain_id,
+            sync_run_id,
+            state: Mutex::new(ProgressState {
+                last_bucket: None,
+                last_emit_at: std::time::Instant::now(),
+            }),
+        }
+    }
+}
+
+impl Progress for TracingBdkProgress {
+    fn update(&self, progress: f32, message: Option<String>) -> Result<(), bdk::Error> {
+        let mut state = self.state.lock().expect("bdk progress mutex poisoned");
+        let elapsed = state.last_emit_at.elapsed();
+
+        if !should_emit_progress(state.last_bucket, progress, elapsed) {
+            return Ok(());
+        }
+
+        let bucket = progress_bucket(progress);
+        state.last_bucket = Some(bucket);
+        state.last_emit_at = std::time::Instant::now();
+
+        tracing::info!(
+            sync_run_id = %self.sync_run_id,
+            wallet_id = %self.wallet_id,
+            keychain_id = %self.keychain_id,
+            progress_pct = progress,
+            progress_message = message.as_deref().unwrap_or(""),
+            "wallet sync progress"
+        );
+
+        Ok(())
+    }
+}
+
+fn progress_bucket(progress: f32) -> u8 {
+    (progress.clamp(0.0, 100.0) as u8 / PROGRESS_BUCKET_SIZE_PCT).min(10)
+}
+
+fn should_emit_progress(
+    last_bucket: Option<u8>,
+    progress: f32,
+    elapsed_since_last_emit: Duration,
+) -> bool {
+    if last_bucket.is_none() {
+        return true;
+    }
+
+    let bucket = progress_bucket(progress);
+    if last_bucket != Some(bucket) {
+        return true;
+    }
+
+    if progress >= 100.0 {
+        return true;
+    }
+
+    elapsed_since_last_emit >= PROGRESS_HEARTBEAT_INTERVAL
 }
 
 impl KeychainWallet {
@@ -105,8 +188,13 @@ impl KeychainWallet {
     pub async fn sync<B: WalletSync + GetHeight + Send + Sync + 'static>(
         &self,
         blockchain: B,
+        wallet_id: WalletId,
+        sync_run_id: String,
     ) -> Result<(), BdkError> {
+        let sync_span = tracing::Span::current();
+        let keychain_id = self.keychain_id;
         self.with_wallet(move |wallet| {
+            let _span_guard = sync_span.enter();
             let last_external = wallet
                 .database()
                 .get_last_index(KeychainKind::External)?
@@ -118,7 +206,13 @@ impl KeychainWallet {
             let max_last_index = last_external.max(last_internal);
 
             let _ = wallet.ensure_addresses_cached(max_last_index.saturating_add(1))?;
-            wallet.sync(&blockchain, Default::default())
+            let progress = TracingBdkProgress::new(wallet_id, keychain_id, sync_run_id);
+            wallet.sync(
+                &blockchain,
+                SyncOptions {
+                    progress: Some(Box::new(progress)),
+                },
+            )
         })
         .await??;
         Ok(())
@@ -172,5 +266,40 @@ impl KeychainWallet {
             Ok(Err(e)) => Err(e),
             Err(e) => Err(e.into()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn emits_first_progress_update() {
+        assert!(should_emit_progress(None, 1.0, Duration::from_secs(1)));
+    }
+
+    #[test]
+    fn emits_when_bucket_changes() {
+        let elapsed = Duration::from_secs(1);
+        assert!(should_emit_progress(Some(0), 11.0, elapsed));
+        assert!(!should_emit_progress(Some(1), 15.0, elapsed));
+    }
+
+    #[test]
+    fn emits_on_heartbeat_interval() {
+        assert!(should_emit_progress(
+            Some(3),
+            35.0,
+            PROGRESS_HEARTBEAT_INTERVAL
+        ));
+    }
+
+    #[test]
+    fn emits_at_completion_even_without_bucket_change() {
+        assert!(should_emit_progress(
+            Some(10),
+            100.0,
+            Duration::from_secs(1)
+        ));
     }
 }

--- a/tests/keychain_wallet.rs
+++ b/tests/keychain_wallet.rs
@@ -9,10 +9,17 @@ async fn new_address() -> anyhow::Result<()> {
     let pool = helpers::init_pool().await?;
 
     let keychain_id = KeychainId::new();
+    let wallet_id = WalletId::new();
     let external = "wpkh([492ef832/84'/0'/0']tpubDCyf42ghP6mBAETwkz8AbXo97822jdUgHNug91bbX8GXpTP6ee298yGeiM5SvgL8Z85bcFyKioyRQokNh6J4eT3Fy8mgKDAKfynovRu3WzE/0/*)#gf2aklqx";
     let internal = "wpkh([492ef832/84'/0'/0']tpubDCyf42ghP6mBAETwkz8AbXo97822jdUgHNug91bbX8GXpTP6ee298yGeiM5SvgL8Z85bcFyKioyRQokNh6J4eT3Fy8mgKDAKfynovRu3WzE/1/*)#ea0ut2s7";
     let keychain_cfg = KeychainConfig::try_from((external, internal)).unwrap();
-    let wallet = KeychainWallet::new(pool.clone(), Network::Regtest, keychain_id, keychain_cfg);
+    let wallet = KeychainWallet::new(
+        pool.clone(),
+        Network::Regtest,
+        wallet_id,
+        keychain_id,
+        keychain_cfg,
+    );
 
     let addr = wallet.new_external_address().await?;
     assert_eq!(

--- a/tests/psbt_builder.rs
+++ b/tests/psbt_builder.rs
@@ -8,12 +8,8 @@ use uuid::Uuid;
 
 use bria::{primitives::*, utxo::*, wallet::*, xpub::*};
 
-fn test_progress_context(wallet_id: WalletId, keychain_id: Uuid) -> SyncProgressContext {
-    SyncProgressContext::with_sync_run_id(
-        wallet_id,
-        keychain_id.into(),
-        String::from("psbt_builder_test"),
-    )
+fn test_progress_context(wallet_id: WalletId) -> SyncProgressContext {
+    SyncProgressContext::with_sync_run_id(wallet_id, String::from("psbt_builder_test"))
 }
 
 #[tokio::test]
@@ -48,10 +44,12 @@ async fn build_psbt() -> anyhow::Result<()> {
     let external = "wpkh([6f2fa1b2/84'/0'/0']tpubDDDDGYiFda8HfJRc2AHFJDxVzzEtBPrKsbh35EaW2UGd5qfzrF2G87ewAgeeRyHEz4iB3kvhAYW1sH6dpLepTkFUzAktumBN8AXeXWE9nd1/0/*)#l6n08zmr";
     let internal = "wpkh([6f2fa1b2/84'/0'/0']tpubDDDDGYiFda8HfJRc2AHFJDxVzzEtBPrKsbh35EaW2UGd5qfzrF2G87ewAgeeRyHEz4iB3kvhAYW1sH6dpLepTkFUzAktumBN8AXeXWE9nd1/1/*)#wwkw6htm";
     let domain_current_keychain_id = Uuid::new_v4();
+    let domain_wallet_id = WalletId::new();
     let keychain_cfg = KeychainConfig::try_from((external, internal))?;
     let domain_current_keychain = KeychainWallet::new(
         pool.clone(),
         Network::Regtest,
+        domain_wallet_id,
         domain_current_keychain_id.into(),
         keychain_cfg,
     );
@@ -69,7 +67,6 @@ async fn build_psbt() -> anyhow::Result<()> {
     let wallet_funding = 700_000_000;
     let wallet_funding_sats = Satoshis::from(wallet_funding);
     let tx_id = helpers::fund_addr(&bitcoind, &domain_addr, wallet_funding)?;
-    let domain_wallet_id = WalletId::new();
     helpers::fund_addr(&bitcoind, &other_current_addr, wallet_funding - 200_000_000)?;
     helpers::fund_addr(&bitcoind, &other_deprecated_addr, 200_000_000)?;
     helpers::gen_blocks(&bitcoind, 10)?;
@@ -91,10 +88,7 @@ async fn build_psbt() -> anyhow::Result<()> {
     while !find_tx_id(&pool, domain_current_keychain_id, tx_id).await? {
         let blockchain = helpers::electrum_blockchain().await?;
         domain_current_keychain
-            .sync(
-                blockchain,
-                test_progress_context(domain_wallet_id, domain_current_keychain_id),
-            )
+            .sync(blockchain, test_progress_context(domain_wallet_id))
             .await?;
     }
 
@@ -244,11 +238,13 @@ async fn build_psbt_with_cpfp() -> anyhow::Result<()> {
     let pool = helpers::init_pool().await?;
 
     let domain_current_keychain_id = Uuid::new_v4();
+    let domain_wallet_id = WalletId::new();
     let xpub = XPub::try_from(("tpubDD4vFnWuTMEcZiaaZPgvzeGyMzWe6qHW8gALk5Md9kutDvtdDjYFwzauEFFRHgov8pAwup5jX88j5YFyiACsPf3pqn5hBjvuTLRAseaJ6b4", Some("m/84'/0'/0'"))).unwrap();
     let keychain_cfg = KeychainConfig::wpkh(xpub);
     let domain_current_keychain = KeychainWallet::new(
         pool.clone(),
         Network::Regtest,
+        domain_wallet_id,
         domain_current_keychain_id.into(),
         keychain_cfg,
     );
@@ -296,7 +292,6 @@ async fn build_psbt_with_cpfp() -> anyhow::Result<()> {
         .unwrap();
     let builder = PsbtBuilder::new(cfg);
 
-    let domain_wallet_id = WalletId::new();
     let domain_send_amount = wallet_funding_sats - Satoshis::from(100_000_000);
     let destination = Address::parse_from_trusted_source("mgWUuj1J1N882jmqFxtDepEC73Rr22E9GU");
     let payouts_one = vec![(Uuid::new_v4(), destination.clone(), domain_send_amount)];
@@ -307,10 +302,7 @@ async fn build_psbt_with_cpfp() -> anyhow::Result<()> {
     while !find_tx_id(&pool, domain_current_keychain_id, tx_id).await? {
         let blockchain = helpers::electrum_blockchain().await?;
         domain_current_keychain
-            .sync(
-                blockchain,
-                test_progress_context(domain_wallet_id, domain_current_keychain_id),
-            )
+            .sync(blockchain, test_progress_context(domain_wallet_id))
             .await?;
     }
     let builder = domain_current_keychain
@@ -397,11 +389,13 @@ async fn build_psbt_with_min_change_output() -> anyhow::Result<()> {
     let pool = helpers::init_pool().await?;
 
     let domain_current_keychain_id = Uuid::new_v4();
+    let domain_wallet_id = WalletId::new();
     let xpub = XPub::try_from(("tpubDD4vFnWuTMEcZiaaZPgvzeGyMzWe6qHW8gALk5Md9kutDvtdDjYFwzauEFFRHgov8pAwup5jX88j5YFyiACsPf3pqn5hBjvuTLRAseaJ6b4", Some("m/84'/0'/0'"))).unwrap();
     let keychain_cfg = KeychainConfig::wpkh(xpub);
     let domain_current_keychain = KeychainWallet::new(
         pool.clone(),
         Network::Regtest,
+        domain_wallet_id,
         domain_current_keychain_id.into(),
         keychain_cfg,
     );
@@ -425,7 +419,6 @@ async fn build_psbt_with_min_change_output() -> anyhow::Result<()> {
         .unwrap();
     let builder = PsbtBuilder::new(cfg);
 
-    let domain_wallet_id = WalletId::new();
     let domain_send_amount = wallet_funding_sats - Satoshis::from(50_000_000);
     let destination = Address::parse_from_trusted_source("mgWUuj1J1N882jmqFxtDepEC73Rr22E9GU");
     let payouts_one = vec![(Uuid::new_v4(), destination.clone(), domain_send_amount)];
@@ -436,10 +429,7 @@ async fn build_psbt_with_min_change_output() -> anyhow::Result<()> {
     while !find_tx_id(&pool, domain_current_keychain_id, tx_id).await? {
         let blockchain = helpers::electrum_blockchain().await?;
         domain_current_keychain
-            .sync(
-                blockchain,
-                test_progress_context(domain_wallet_id, domain_current_keychain_id),
-            )
+            .sync(blockchain, test_progress_context(domain_wallet_id))
             .await?;
     }
     let builder = domain_current_keychain

--- a/tests/psbt_builder.rs
+++ b/tests/psbt_builder.rs
@@ -61,6 +61,7 @@ async fn build_psbt() -> anyhow::Result<()> {
     let wallet_funding = 700_000_000;
     let wallet_funding_sats = Satoshis::from(wallet_funding);
     let tx_id = helpers::fund_addr(&bitcoind, &domain_addr, wallet_funding)?;
+    let domain_wallet_id = WalletId::new();
     helpers::fund_addr(&bitcoind, &other_current_addr, wallet_funding - 200_000_000)?;
     helpers::fund_addr(&bitcoind, &other_deprecated_addr, 200_000_000)?;
     helpers::gen_blocks(&bitcoind, 10)?;
@@ -81,7 +82,7 @@ async fn build_psbt() -> anyhow::Result<()> {
     }
     while !find_tx_id(&pool, domain_current_keychain_id, tx_id).await? {
         let blockchain = helpers::electrum_blockchain().await?;
-        domain_current_keychain.sync(blockchain).await?;
+        domain_current_keychain.sync(blockchain, None).await?;
     }
 
     let fee = FeeRate::from_sat_per_vb(1.0);
@@ -92,7 +93,6 @@ async fn build_psbt() -> anyhow::Result<()> {
         .unwrap();
     let builder = PsbtBuilder::new(cfg);
 
-    let domain_wallet_id = WalletId::new();
     let domain_send_amount = wallet_funding_sats - Satoshis::from(155);
     let other_wallet_id = WalletId::new();
     let send_amount = Satoshis::from(100_000_000);
@@ -293,7 +293,7 @@ async fn build_psbt_with_cpfp() -> anyhow::Result<()> {
         .accept_current_keychain();
     while !find_tx_id(&pool, domain_current_keychain_id, tx_id).await? {
         let blockchain = helpers::electrum_blockchain().await?;
-        domain_current_keychain.sync(blockchain).await?;
+        domain_current_keychain.sync(blockchain, None).await?;
     }
     let builder = domain_current_keychain
         .dispatch_bdk_wallet(builder)
@@ -417,7 +417,7 @@ async fn build_psbt_with_min_change_output() -> anyhow::Result<()> {
         .accept_current_keychain();
     while !find_tx_id(&pool, domain_current_keychain_id, tx_id).await? {
         let blockchain = helpers::electrum_blockchain().await?;
-        domain_current_keychain.sync(blockchain).await?;
+        domain_current_keychain.sync(blockchain, None).await?;
     }
     let builder = domain_current_keychain
         .dispatch_bdk_wallet(builder)

--- a/tests/psbt_builder.rs
+++ b/tests/psbt_builder.rs
@@ -8,6 +8,14 @@ use uuid::Uuid;
 
 use bria::{primitives::*, utxo::*, wallet::*, xpub::*};
 
+fn test_progress_context(wallet_id: WalletId, keychain_id: Uuid) -> SyncProgressContext {
+    SyncProgressContext::with_sync_run_id(
+        wallet_id,
+        keychain_id.into(),
+        String::from("psbt_builder_test"),
+    )
+}
+
 #[tokio::test]
 #[serial]
 async fn build_psbt() -> anyhow::Result<()> {
@@ -82,7 +90,12 @@ async fn build_psbt() -> anyhow::Result<()> {
     }
     while !find_tx_id(&pool, domain_current_keychain_id, tx_id).await? {
         let blockchain = helpers::electrum_blockchain().await?;
-        domain_current_keychain.sync(blockchain, None).await?;
+        domain_current_keychain
+            .sync(
+                blockchain,
+                test_progress_context(domain_wallet_id, domain_current_keychain_id),
+            )
+            .await?;
     }
 
     let fee = FeeRate::from_sat_per_vb(1.0);
@@ -293,7 +306,12 @@ async fn build_psbt_with_cpfp() -> anyhow::Result<()> {
         .accept_current_keychain();
     while !find_tx_id(&pool, domain_current_keychain_id, tx_id).await? {
         let blockchain = helpers::electrum_blockchain().await?;
-        domain_current_keychain.sync(blockchain, None).await?;
+        domain_current_keychain
+            .sync(
+                blockchain,
+                test_progress_context(domain_wallet_id, domain_current_keychain_id),
+            )
+            .await?;
     }
     let builder = domain_current_keychain
         .dispatch_bdk_wallet(builder)
@@ -417,7 +435,12 @@ async fn build_psbt_with_min_change_output() -> anyhow::Result<()> {
         .accept_current_keychain();
     while !find_tx_id(&pool, domain_current_keychain_id, tx_id).await? {
         let blockchain = helpers::electrum_blockchain().await?;
-        domain_current_keychain.sync(blockchain, None).await?;
+        domain_current_keychain
+            .sync(
+                blockchain,
+                test_progress_context(domain_wallet_id, domain_current_keychain_id),
+            )
+            .await?;
     }
     let builder = domain_current_keychain
         .dispatch_bdk_wallet(builder)

--- a/tests/psbt_builder.rs
+++ b/tests/psbt_builder.rs
@@ -8,8 +8,8 @@ use uuid::Uuid;
 
 use bria::{primitives::*, utxo::*, wallet::*, xpub::*};
 
-fn test_progress_context(wallet_id: WalletId) -> SyncProgressContext {
-    SyncProgressContext::with_sync_run_id(wallet_id, String::from("psbt_builder_test"))
+fn test_progress_context() -> SyncProgressContext {
+    SyncProgressContext::new()
 }
 
 #[tokio::test]
@@ -88,7 +88,7 @@ async fn build_psbt() -> anyhow::Result<()> {
     while !find_tx_id(&pool, domain_current_keychain_id, tx_id).await? {
         let blockchain = helpers::electrum_blockchain().await?;
         domain_current_keychain
-            .sync(blockchain, test_progress_context(domain_wallet_id))
+            .sync(blockchain, test_progress_context())
             .await?;
     }
 
@@ -302,7 +302,7 @@ async fn build_psbt_with_cpfp() -> anyhow::Result<()> {
     while !find_tx_id(&pool, domain_current_keychain_id, tx_id).await? {
         let blockchain = helpers::electrum_blockchain().await?;
         domain_current_keychain
-            .sync(blockchain, test_progress_context(domain_wallet_id))
+            .sync(blockchain, test_progress_context())
             .await?;
     }
     let builder = domain_current_keychain
@@ -429,7 +429,7 @@ async fn build_psbt_with_min_change_output() -> anyhow::Result<()> {
     while !find_tx_id(&pool, domain_current_keychain_id, tx_id).await? {
         let blockchain = helpers::electrum_blockchain().await?;
         domain_current_keychain
-            .sync(blockchain, test_progress_context(domain_wallet_id))
+            .sync(blockchain, test_progress_context())
             .await?;
     }
     let builder = domain_current_keychain


### PR DESCRIPTION
## Summary
- wire BDK sync progress callback in keychain wallet sync
- emit throttled progress logs (10% buckets + 30s heartbeat)
- add sync_run_id + sync phase lifecycle logs in sync wallet job
- refactor sync context passing via `SyncProgressContext` and update test callsites

## Additional Tracing Improvements
- register global OTEL text-map propagator and tracer provider
- add optional `tracing.sample_ratio` for ratio-based sampling control
- use global propagator in trace context inject/extract helpers
- shutdown tracer provider on daemon exit path

## Verification
- SQLX_OFFLINE=true cargo fmt --all
- direnv exec . make check-code
- direnv exec . cargo nextest run