### PR TITLE
fix: optimize script pubkey listing for large keychains

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,2 +1,9 @@
 [advisories]
-ignore = ["RUSTSEC-2023-0071", "RUSTSEC-2026-0049"]
+ignore = [
+    "RUSTSEC-2023-0071",
+    "RUSTSEC-2026-0049",
+    # TODO: remove once electrum-client/bdk stop pulling rustls-webpki 0.101.7
+    "RUSTSEC-2026-0098",
+    # TODO: remove once electrum-client/bdk stop pulling rustls-webpki 0.101.7
+    "RUSTSEC-2026-0099",
+]

--- a/.sqlx/query-677952b237d5be17199de794ceca814e02cb5396ccb8fce263922191ec5d1857.json
+++ b/.sqlx/query-677952b237d5be17199de794ceca814e02cb5396ccb8fce263922191ec5d1857.json
@@ -1,17 +1,18 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT script, keychain_kind as \"keychain_kind: BdkKeychainKind\" FROM bdk_script_pubkeys\n            WHERE keychain_id = $1",
+  "query": "SELECT script FROM bdk_script_pubkeys\n                    WHERE keychain_id = $1 AND keychain_kind = $2",
   "describe": {
     "columns": [
       {
         "ordinal": 0,
         "name": "script",
         "type_info": "Bytea"
-      },
-      {
-        "ordinal": 1,
-        "name": "keychain_kind: BdkKeychainKind",
-        "type_info": {
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        {
           "Custom": {
             "name": "bdkkeychainkind",
             "kind": {
@@ -22,17 +23,11 @@
             }
           }
         }
-      }
-    ],
-    "parameters": {
-      "Left": [
-        "Uuid"
       ]
     },
     "nullable": [
-      false,
       false
     ]
   },
-  "hash": "79eff690e77e488dccc3c066b265e7718128987e44d97f408059cca30fc5124c"
+  "hash": "677952b237d5be17199de794ceca814e02cb5396ccb8fce263922191ec5d1857"
 }

--- a/.sqlx/query-df372e7e6ab68e247c1a8cefd2410c6d3e30dff29b5b733d4817ad1a9bed2843.json
+++ b/.sqlx/query-df372e7e6ab68e247c1a8cefd2410c6d3e30dff29b5b733d4817ad1a9bed2843.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT script FROM bdk_script_pubkeys\n                    WHERE keychain_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "script",
+        "type_info": "Bytea"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "df372e7e6ab68e247c1a8cefd2410c6d3e30dff29b5b733d4817ad1a9bed2843"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,7 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.32",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -251,13 +251,38 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
  "serde",
+ "sync_wrapper 1.0.2",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core 0.5.6",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
  "sync_wrapper 1.0.2",
  "tower 0.5.3",
  "tower-layer",
@@ -296,6 +321,24 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
  "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
@@ -1122,22 +1165,21 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fedimint-tonic-lnd"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df03ca33b5116de3051c1e233fe341e23b04c4913c7b16042497924559bc2a2e"
+checksum = "544e07140e0b295035d28068a66ed752ada57762571ddbb3ac54124c3d9cc892"
 dependencies = [
  "hex",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "prost 0.12.6",
- "rustls 0.21.12",
+ "hyper 1.8.1",
+ "hyper-rustls",
+ "hyper-util",
+ "prost 0.13.5",
+ "rustls 0.23.37",
  "rustls-pemfile 1.0.4",
  "tokio",
  "tokio-stream",
- "tonic 0.10.2",
- "tonic-build 0.10.2",
- "tower 0.4.13",
+ "tonic 0.13.1",
+ "tonic-build 0.13.1",
 ]
 
 [[package]]
@@ -1647,20 +1689,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
@@ -1671,7 +1699,7 @@ dependencies = [
  "rustls 0.23.37",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.6",
 ]
@@ -2120,6 +2148,12 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -2660,7 +2694,27 @@ dependencies = [
  "petgraph 0.6.5",
  "prettyplease",
  "prost 0.12.6",
- "prost-types",
+ "prost-types 0.12.6",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph 0.7.1",
+ "prettyplease",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
  "regex",
  "syn 2.0.117",
  "tempfile",
@@ -2702,6 +2756,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost 0.13.5",
+]
+
+[[package]]
 name = "prost-wkt"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2724,8 +2787,8 @@ checksum = "598b7365952c2ed4e32902de0533653aafbe5ae3da436e8e2335c7d375a1cef3"
 dependencies = [
  "heck",
  "prost 0.12.6",
- "prost-build",
- "prost-types",
+ "prost-build 0.12.6",
+ "prost-types 0.12.6",
  "quote",
 ]
 
@@ -2737,8 +2800,8 @@ checksum = "1a8eadc2381640a49c1fbfb9f4a857794b4e5bf5a2cbc2d858cfdb74f64dcd22"
 dependencies = [
  "chrono",
  "prost 0.12.6",
- "prost-build",
- "prost-types",
+ "prost-build 0.12.6",
+ "prost-types 0.12.6",
  "prost-wkt",
  "prost-wkt-build",
  "protobuf-src",
@@ -3042,7 +3105,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
@@ -3056,7 +3119,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower 0.5.3",
  "tower-http",
  "tower-service",
@@ -3244,7 +3307,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.12",
  "subtle",
  "zeroize",
 ]
@@ -3289,9 +3352,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4254,16 +4317,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
@@ -4329,36 +4382,6 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum 0.6.20",
- "base64 0.21.7",
- "bytes",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-timeout 0.4.1",
- "percent-encoding",
- "pin-project",
- "prost 0.12.6",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
- "tokio",
- "tokio-rustls 0.24.1",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
@@ -4415,16 +4438,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic-build"
-version = "0.10.2"
+name = "tonic"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d021fc044c18582b9a2408cd0dd05b1596e3ecdb5c4df822bb0183545683889"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
- "prettyplease",
- "proc-macro2",
- "prost-build",
- "quote",
- "syn 2.0.117",
+ "async-trait",
+ "axum 0.8.9",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-timeout 0.5.2",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.5",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4435,7 +4474,21 @@ checksum = "be4ef6dd70a610078cb4e338a0f79d06bc759ff1b22d2120c2ff02ae264ba9c2"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build",
+ "prost-build 0.12.6",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build 0.13.5",
+ "prost-types 0.13.5",
  "quote",
  "syn 2.0.117",
 ]
@@ -4481,11 +4534,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.13.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ miniscript = "10.0"
 reqwest-retry = "0.5.0"
 reqwest-middleware = "0.3"
 governor = "0.8.1"
-tonic_lnd = { version = "0.2.0", package = "fedimint-tonic-lnd", features = [
+tonic_lnd = { version = "0.4.0", package = "fedimint-tonic-lnd", features = [
     "lightningrpc",
 ] }
 

--- a/migrations/20260415120000_optimize_bdk_script_pubkeys_list_scripts.down.sql
+++ b/migrations/20260415120000_optimize_bdk_script_pubkeys_list_scripts.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS bdk_script_pubkeys_keychain_kind_script_idx;

--- a/migrations/20260415120000_optimize_bdk_script_pubkeys_list_scripts.up.sql
+++ b/migrations/20260415120000_optimize_bdk_script_pubkeys_list_scripts.up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS bdk_script_pubkeys_keychain_kind_script_idx
+ON bdk_script_pubkeys (keychain_id, keychain_kind)
+INCLUDE (script);

--- a/src/bdk/pg/script_pubkeys.rs
+++ b/src/bdk/pg/script_pubkeys.rs
@@ -120,28 +120,29 @@ impl ScriptPubkeys {
         &self,
         keychain: Option<impl Into<BdkKeychainKind>>,
     ) -> Result<Vec<ScriptBuf>, bdk::Error> {
-        let kind = keychain.map(|k| k.into());
-        let rows = sqlx::query!(
-            r#"SELECT script, keychain_kind as "keychain_kind: BdkKeychainKind" FROM bdk_script_pubkeys
-            WHERE keychain_id = $1"#,
-            Uuid::from(self.keychain_id),
-        )
-        .fetch_all(&self.pool)
-        .await
+        let rows = match keychain.map(|k| k.into()) {
+            Some(kind) => {
+                sqlx::query_scalar!(
+                    r#"SELECT script FROM bdk_script_pubkeys
+                    WHERE keychain_id = $1 AND keychain_kind = $2"#,
+                    Uuid::from(self.keychain_id),
+                    kind as BdkKeychainKind,
+                )
+                .fetch_all(&self.pool)
+                .await
+            }
+            None => {
+                sqlx::query_scalar!(
+                    r#"SELECT script FROM bdk_script_pubkeys
+                    WHERE keychain_id = $1"#,
+                    Uuid::from(self.keychain_id),
+                )
+                .fetch_all(&self.pool)
+                .await
+            }
+        }
         .map_err(|e| bdk::Error::Generic(e.to_string()))?;
-        Ok(rows
-            .into_iter()
-            .filter_map(|row| {
-                if let Some(kind) = kind {
-                    if kind == row.keychain_kind {
-                        Some(ScriptBuf::from(row.script))
-                    } else {
-                        None
-                    }
-                } else {
-                    Some(ScriptBuf::from(row.script))
-                }
-            })
-            .collect())
+
+        Ok(rows.into_iter().map(ScriptBuf::from).collect())
     }
 }


### PR DESCRIPTION
## Summary
- Move `bdk.script_pubkeys.list_scripts` filtering into SQL so keychain-kind queries avoid fetching and filtering all rows in Rust.
- Add a covering index on `bdk_script_pubkeys (keychain_id, keychain_kind) INCLUDE (script)` to improve large keychain reads.
- Regenerate SQLx metadata and include dependency/audit config updates that were part of this fix branch.