### PR TITLE
chore: use stable rust toolchain and fix rust 1.95 clippy lints

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775185947,
-        "narHash": "sha256-8ctPmj6RME4q4ELeg+BuY9lV/34M4AG1CNc0Im9PDDk=",
+        "lastModified": 1776350315,
+        "narHash": "sha256-ijD4bgb5Iyap9F3MX73vLAZF/SYu+q7Gd7Ux4cbfCWw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "199eeb6748116f7da4fbd3a680bc854e99d9132b",
+        "rev": "62e3b8aedabc240e5b0cc9fae003bc9edfebbc9b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,6 @@
       url = "github:oxalica/rust-overlay";
       inputs = {
         nixpkgs.follows = "nixpkgs";
-        flake-utils.follows = "flake-utils";
       };
     };
   };

--- a/src/fees/mod.rs
+++ b/src/fees/mod.rs
@@ -180,7 +180,7 @@ pub fn allocate_proportional_fees(
         .sum();
 
     let mut remainder = total_fees;
-    payouts.sort_by(|a, b| a.1.cmp(&b.1));
+    payouts.sort_by_key(|a| a.1);
 
     let n_payouts = payouts.len();
     let mut proportional_fees = HashMap::new();

--- a/src/job/process_payout_queue.rs
+++ b/src/job/process_payout_queue.rs
@@ -128,7 +128,7 @@ pub(super) async fn execute<'a>(
 
         // Not using a Box here causes an interesting compile error with rustc 1.69.0
         let included_utxos: Box<dyn Iterator<Item = (KeychainId, bitcoin::OutPoint)> + Send> =
-            Box::new(included_utxos.into_iter().flat_map(|(_, keychain_map)| {
+            Box::new(included_utxos.into_values().flat_map(|keychain_map| {
                 keychain_map
                     .into_iter()
                     .flat_map(|(keychain_id, outpoints)| {


### PR DESCRIPTION
## Summary
- set Rust toolchain selection to `stable` via `rust-toolchain.toml` and refresh the flake lock so Nix resolves the current stable compiler
- remove an invalid `flake-utils` follow override under `rust-overlay` in `flake.nix`
- update Rust 1.95 Clippy-triggered patterns in fee allocation sorting and payout queue UTXO flattening