### PR TITLE
test: bitcoind update to v31.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,11 +73,11 @@ services:
     volumes:
       - ./dev/otel-agent-config.yaml:/etc/otel-agent-config.yaml
   bitcoind:
-    image: lnliz/bitcoind:v28.4
+    image: lnliz/bitcoind:v31.1
     volumes:
       - ${HOST_PROJECT_PATH:-.}/dev/bitcoind/bitcoin.conf:/data/.bitcoin/bitcoin.conf
   bitcoind-signer:
-    image: lnliz/bitcoind:v28.4
+    image: lnliz/bitcoind:v31.1
     volumes:
       - ${HOST_PROJECT_PATH:-.}/dev/bitcoind/bitcoin.conf:/data/.bitcoin/bitcoin.conf
     depends_on: [bitcoind]

--- a/tests/e2e/helpers.bash
+++ b/tests/e2e/helpers.bash
@@ -498,7 +498,8 @@ wallet_effective_settled_is_not() {
 
 signer_unconfirmed_balance_is() {
   local expected="$1"
-  [[ "$(bitcoin_signer_cli getunconfirmedbalance)" == "${expected}" ]]
+  bitcoin_signer_cli getbalances |
+    jq -e --argjson expected "${expected}" '.mine.untrusted_pending == $expected' >/dev/null
 }
 
 wallet_effective_settled_matches_signer_balance() {


### PR DESCRIPTION
## Summary

- update the bitcoind and signer test containers to v31.1
- use the supported wallet balance RPC in E2E assertions

## Validation

- `nix develop -c make e2e` (34/34 passed locally)
- GitHub E2E Tests, Integration Tests, and Spelling pass

Audit remediation lands first in #68; this PR is stacked on that branch.
