### PR TITLE
fix: address cargo audit failures

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -6,4 +6,6 @@ ignore = [
     "RUSTSEC-2026-0098",
     "RUSTSEC-2026-0099",
     "RUSTSEC-2026-0104",
+    # rkyv is an inactive optional rust_decimal dependency with no patched 0.7 release
+    "RUSTSEC-2026-0235",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2877,9 +2877,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Summary

- refresh advisory-affected transitive lockfile entries
- document the inactive optional dependency exception that has no compatible patched release

## Validation

- `nix develop -c make check-code`
- full combined-stack E2E suite: 34/34 tests passed locally

First PR in the stack; #65 follows this branch.

Supersedes #66, which GitHub automatically marked merged during the stack reorder.
