### PR TITLE
fix: address Clippy map iteration lints

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1069,7 +1069,7 @@ impl App {
             .list_for_batch(profile.account_id, batch_id)
             .await?;
 
-        for (_wallet_id, wallet_payouts) in payouts.iter() {
+        for wallet_payouts in payouts.values() {
             for payout in wallet_payouts {
                 // Skip committed check since we're cancelling the whole batch
                 // and we've already verified the batch isn't signed

--- a/src/wallet/psbt_builder.rs
+++ b/src/wallet/psbt_builder.rs
@@ -143,7 +143,7 @@ impl<T> PsbtBuilder<T> {
             let outputs = &psbt.unsigned_tx.output;
 
             // Identify change outputs
-            for (_, total) in ret.wallet_totals.iter_mut() {
+            for total in ret.wallet_totals.values_mut() {
                 if total.change_satoshis == Satoshis::ZERO {
                     continue;
                 }


### PR DESCRIPTION
Iterate directly over HashMap values when the associated keys are unused.

Use values() while cancelling payouts during a batch drop, and
values_mut() while assigning change outpoints to wallet totals.

This satisfies Clippy's for_kv_map lint without changing application
behavior.