### PR TITLE
ci: run check-code in the locked Nix environment

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -4,7 +4,7 @@
 #@   "build_edge_image",
 #@   "public_docker_registry",
 #@   "nodejs_task_image_config",
-#@   "rust_check_code",
+#@   "check_code",
 #@   "docker_host_pool",
 #@   "test_on_docker_host",
 #@   "repo_resource",
@@ -31,7 +31,7 @@ groups:
   - build-edge-image
 
 jobs:
-- #@ rust_check_code()
+- #@ check_code()
 - #@ test_on_docker_host("integration-tests")
 - #@ test_on_docker_host("e2e-tests")
 


### PR DESCRIPTION
- [x] needs repipe in ci

Check code passed with this change in CI:
<img width="504" height="345" alt="image" src="https://github.com/user-attachments/assets/916c1bb7-574a-4bb5-99a2-6df3c176c0d7" />
